### PR TITLE
Fix minikube profile

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -3,9 +3,11 @@
 USERNAME=`id -un`
 cd ~/.kube
 mkdir -p keys
+
+profile=$(minikube profile list -o json | jq '.valid' | jq -r '.[].Name')
 cp /Users/${USERNAME}/.minikube/ca.crt keys/
-cp /Users/${USERNAME}/.minikube/profiles/minikube/client.crt keys/
-cp /Users/${USERNAME}/.minikube/profiles/minikube/client.key keys/
+cp /Users/${USERNAME}/.minikube/profiles/$profile/client.crt keys/
+cp /Users/${USERNAME}/.minikube/profiles/$profile/client.key keys/
 
 gsed -i "s/\/Users\/${USERNAME}\/.minikube\/profiles\/minikube/.\/keys/g" config
 gsed -i "s/\/Users\/${USERNAME}\/.minikube/.\/keys/g" config


### PR DESCRIPTION
It is not fixed that user will always run minikube cluster as default as
specified in readme. They can do it like `minikube start -p
test-cluster`. So to fix the problem, updated the script file.

Signed-off-by: knrt10 <tripathi.kautilya@gmail.com>